### PR TITLE
feat: Refactor VM object to inherit from Host

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: MIT
+repos:
+    - repo: local
+      hooks:
+      - id: code-format
+        name: code-format
+        entry: mfd-format-code
+        language: python
+        types: [ python ]
+        pass_filenames: false
+        verbose: true
+        additional_dependencies: [ mfd-code-quality==1.2.1 ]
+      - id: code-standard
+        name: code-standard
+        entry: mfd-code-standard
+        language: python
+        types: [ python ]
+        pass_filenames: false
+        verbose: true
+        additional_dependencies: [ mfd-code-quality==1.2.1 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,24 @@ Changelog = "https://github.com/intel/mfd-hyperv/blob/main/CHANGELOG.md"
 
 [tool.setuptools.packages.find]
 exclude = ["examples", "tests*", "sphinx-doc"]
+
+[tool.black]
+line-length = 119
+exclude = '''
+(
+    /(
+        \.eggs
+      | \.git
+      | \.hg
+      | \.mypy_cache
+      | \.tox
+      | \.venv
+      | _build
+      | buck-out
+      | build
+      | dist
+      | examples
+    )/
+    | setup.py
+)
+'''

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ mfd-typing >= 1.23.0, < 2
 mfd_connect >= 7.12.0, < 8
 mfd-ping >= 1.15.0, < 2
 mfd_network_adapter >= 14.0.0, < 15
+mfd-host >= 2.0.0, < 3

--- a/tests/unit/test_mfd_hyperv/test_vm.py
+++ b/tests/unit/test_mfd_hyperv/test_vm.py
@@ -50,16 +50,11 @@ class TestVM:
             vswitch_name="vswitch",
         )
 
-        vm_dict = vm.__dict__
-
-        del vm_dict["owner"]
-        del vm_dict["guest"]
-        del vm_dict["_hyperv"]
-        del vm_dict["attributes"]
-        del vm_dict["connection"]
-        del vm_dict["connection_timeout"]
+        vm_dict = vm.vm_params.__dict__
 
         assert vm_dict == vm_params.__dict__
+        assert vm.mng_ip == vm_params.mng_ip
+        assert vm.name == vm_params.name
 
     def test_get_attributes(self, vm, mocker):
         mocker.patch("mfd_hyperv.hypervisor.HypervHypervisor.get_vm_attributes", return_value="x")


### PR DESCRIPTION
This pull request refactors the `VM` class in `mfd_hyperv/instances/vm.py` to inherit from the `Host` class, adjusts its initialization logic to bypass the `Host` factory pattern, and makes several minor documentation and code improvements. The changes improve code reuse, maintainability, and clarity.

### Class inheritance and initialization refactor:
* Updated the `VM` class to inherit from `Host` and overrode the `__new__` method to bypass the `Host` factory pattern for VM instances. The constructor now calls `super().__init__`, passing the `connection` and any additional keyword arguments. This enables better code reuse and integration with the `Host` class while maintaining the specific instantiation logic required for VMs. [[1]](diffhunk://#diff-bb500396c9f05f2bb9ee03d4081a2ef2b67f63a50331f67af8ff0010a0a8c917R11-R12) [[2]](diffhunk://#diff-bb500396c9f05f2bb9ee03d4081a2ef2b67f63a50331f67af8ff0010a0a8c917L27-R34) [[3]](diffhunk://#diff-bb500396c9f05f2bb9ee03d4081a2ef2b67f63a50331f67af8ff0010a0a8c917R43-L45)

### Documentation and readability improvements:
* Fixed typos and clarified docstrings for methods and properties, such as correcting "untill" to "until" and standardizing the spelling of "HyperV" and "vNICs" in property and parameter descriptions. [[1]](diffhunk://#diff-bb500396c9f05f2bb9ee03d4081a2ef2b67f63a50331f67af8ff0010a0a8c917L54-R60) [[2]](diffhunk://#diff-bb500396c9f05f2bb9ee03d4081a2ef2b67f63a50331f67af8ff0010a0a8c917L66-R72) [[3]](diffhunk://#diff-bb500396c9f05f2bb9ee03d4081a2ef2b67f63a50331f67af8ff0010a0a8c917L133-R139) [[4]](diffhunk://#diff-bb500396c9f05f2bb9ee03d4081a2ef2b67f63a50331f67af8ff0010a0a8c917L174-R180)